### PR TITLE
Fix: migrate to compose v2, alter deprecated docker-compose command

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -63,7 +63,7 @@ info "Detected Kafka Version: $KAFKA_VERSION"
 info "Bringing up Kafka environment"
 
 # Use envsubst to replace environment variables in docker-compose.yml and bring up Docker containers
-envsubst < docker-compose.yml | docker-compose up -d
+envsubst < docker-compose.yml | docker compose up -d
 sleep 10 
 
 # Log information about connecting to Kafka


### PR DESCRIPTION
On ubuntu-latest, no longer works because docker compose v1 deprecated on github actions.

* https://github.com/actions/runner-images/issues/9557
* https://github.com/spicyparrot/kafka-kraft-action/issues/15

This PR includes migration compose v1 to v2 like this docs: https://docs.docker.com/compose/migrate/